### PR TITLE
jx-quickstart-py to 0.0.4

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,4 +9,4 @@ dependencies:
   version: 2.3.89
 - name: jx-quickstart-py
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.1
+  version: 0.0.4


### PR DESCRIPTION
Promote jx-quickstart-py to version 0.0.4